### PR TITLE
Update flux2 package to v2.8.7

### DIFF
--- a/flux2/flux2.nuspec
+++ b/flux2/flux2.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>flux</id>
-    <version>2.8.6</version>
+    <version>2.8.7</version>
     <iconUrl>https://cdn.statically.io/gh/jimpruitt/chocolatey-packages/master/flux2/flux2.png</iconUrl>
     <packageSourceUrl>https://github.com/JimPruitt/chocolatey-packages/tree/master/</packageSourceUrl>
     <projectSourceUrl>https://github.com/fluxcd/flux2</projectSourceUrl>

--- a/flux2/tools/chocolateyinstall.ps1
+++ b/flux2/tools/chocolateyinstall.ps1
@@ -1,18 +1,16 @@
-$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop'
 
-    $toolsDir    = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
-    
-    $xargs = @{
-        'PackageName'    ="flux";
-        'Unziplocation'  = $(Split-Path -Parent $MyInvocation.MyCommand.Definition)
-        'Url'            = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_windows_386.zip";
-        'Url64Bit'       = "https://github.com/fluxcd/flux2/releases/download/v2.8.6/flux_2.8.6_windows_amd64.zip"
-        'Checksum'       = "AB38219399DED90881D670DC4CD36052D2CD5C347CD5881EA45084B507ACDD68";
-        'Checksum64'     = "05FE1B414BB40555D72E8149ACA7046EBA4CEACEA7825D011C1188CC74C62E9C"
-        'ChecksumType'   = "SHA256"
-        'ChecksumType64' = "SHA256"
-    }
-    
-    #Download the file from releases
-    Install-ChocolateyZipPackage @xargs
+$toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 
+$xargs = @{
+    'PackageName'    = "flux"
+    'UnzipLocation'  = $(Split-Path -Parent $MyInvocation.MyCommand.Definition)
+    'Url'            = "https://github.com/fluxcd/flux2/releases/download/v2.8.7/flux_2.8.7_windows_386.zip"
+    'Url64Bit'       = "https://github.com/fluxcd/flux2/releases/download/v2.8.7/flux_2.8.7_windows_amd64.zip"
+    'Checksum'       = "FC93DC0756EC0F10B5B67FCD67307703CB3ABEDA482626743FAFD105ADCF2FE6"
+    'Checksum64'     = "E703C645180D2665269F5643408CD257C2553E2245F5F3AD577EDD1DE2B4092B"
+    'ChecksumType'   = "SHA256"
+    'ChecksumType64' = "SHA256"
+}
+
+Install-ChocolateyZipPackage @xargs


### PR DESCRIPTION
Automated update of the flux2 Chocolatey package to version 2.8.7.

Chocolatey push completed successfully. Version verified via `flux --version`.