### PR TITLE
Update flux2 package to v2.8.8

### DIFF
--- a/flux2/flux2.nuspec
+++ b/flux2/flux2.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>flux</id>
-    <version>2.8.7</version>
+    <version>2.8.8</version>
     <iconUrl>https://cdn.statically.io/gh/jimpruitt/chocolatey-packages/master/flux2/flux2.png</iconUrl>
     <packageSourceUrl>https://github.com/JimPruitt/chocolatey-packages/tree/master/</packageSourceUrl>
     <projectSourceUrl>https://github.com/fluxcd/flux2</projectSourceUrl>

--- a/flux2/tools/chocolateyinstall.ps1
+++ b/flux2/tools/chocolateyinstall.ps1
@@ -5,10 +5,10 @@ $toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 $xargs = @{
     'PackageName'    = "flux"
     'UnzipLocation'  = $(Split-Path -Parent $MyInvocation.MyCommand.Definition)
-    'Url'            = "https://github.com/fluxcd/flux2/releases/download/v2.8.7/flux_2.8.7_windows_386.zip"
-    'Url64Bit'       = "https://github.com/fluxcd/flux2/releases/download/v2.8.7/flux_2.8.7_windows_amd64.zip"
-    'Checksum'       = "FC93DC0756EC0F10B5B67FCD67307703CB3ABEDA482626743FAFD105ADCF2FE6"
-    'Checksum64'     = "E703C645180D2665269F5643408CD257C2553E2245F5F3AD577EDD1DE2B4092B"
+    'Url'            = "https://github.com/fluxcd/flux2/releases/download/v2.8.8/flux_2.8.8_windows_386.zip"
+    'Url64Bit'       = "https://github.com/fluxcd/flux2/releases/download/v2.8.8/flux_2.8.8_windows_amd64.zip"
+    'Checksum'       = "349DAF916A40D896648FEFED0AE66C1C12CCED2FC9807CA161C049BFD9593460"
+    'Checksum64'     = "78045FF9A4E2A6C05265D7A027694FBACA43F08F782DA5C9214F852E06189BF8"
     'ChecksumType'   = "SHA256"
     'ChecksumType64' = "SHA256"
 }


### PR DESCRIPTION
Automated update of the flux2 Chocolatey package to version 2.8.8.

Chocolatey push completed successfully. Version verified via `flux --version`.